### PR TITLE
fix: error suppression in WithTimeout()

### DIFF
--- a/cli_errors_test.go
+++ b/cli_errors_test.go
@@ -1,0 +1,95 @@
+package hype_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func buildBin(binPath string) {
+	buildCmd := exec.Command("go", "build", "-o", binPath, "./cmd/hype")
+	if err := buildCmd.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getProjectWd() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+func Test_Cli_Error(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	binPath := filepath.Join(t.TempDir(), "hype")
+	buildBin(binPath)
+
+	root := filepath.Join(getProjectWd(), "testdata", "to_md", "source_code", "broken")
+	err := os.Chdir(root)
+	r.NoError(err)
+
+	args := []string{"export", "-format=markdown", "-f", "hype.md"}
+	hypeCmd := exec.Command(binPath, args...)
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+	hypeCmd.Stderr = &stderr
+	hypeCmd.Stdout = &stdout
+
+	err = hypeCmd.Run()
+	r.Error(err)
+
+	r.Equal(0, stdout.Len())
+
+	var exitErr *exec.ExitError
+	r.True(errors.As(err, &exitErr), "expected exec.ExitError, got %T", err)
+
+	exitCode := hypeCmd.ProcessState.ExitCode()
+	r.Equal(1, exitCode)
+}
+
+func Test_Cli_Success(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	binPath := filepath.Join(t.TempDir(), "hype")
+	buildBin(binPath)
+
+	root := filepath.Join(getProjectWd(), "testdata", "to_md", "source_code", "full")
+	err := os.Chdir(root)
+	r.NoError(err)
+
+	args := []string{"export", "-format=markdown", "-f", "hype.md"}
+	hypeCmd := exec.Command(binPath, args...)
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+	hypeCmd.Stderr = &stderr
+	hypeCmd.Stdout = &stdout
+
+	err = hypeCmd.Run()
+	if err != nil {
+		fmt.Printf("%s\n", stderr.String())
+	}
+	r.NoError(err)
+	r.Equal(0, stderr.Len())
+	r.True(stdout.Len() > 0)
+
+	exitCode := hypeCmd.ProcessState.ExitCode()
+	r.Equal(0, exitCode)
+
+	b, err := os.ReadFile(filepath.Join(root, "hype.gold"))
+	r.NoError(err)
+	exp := strings.TrimSpace(string(b))
+	act := strings.TrimSpace(stdout.String())
+
+	r.Equal(exp, act)
+}

--- a/cmd/hype/cli/cli.go
+++ b/cmd/hype/cli/cli.go
@@ -197,24 +197,23 @@ func WithTimeout(ctx context.Context, timeout time.Duration, f func(context.Cont
 	}
 
 	cltx, cancel := context.WithTimeout(ctx, timeout)
+	errCh := make(chan error, 1)
+
 	defer cancel()
 
-	cltx, cause := context.WithCancelCause(cltx)
-
 	go func() {
-		defer cancel()
-		err := f(cltx)
-		if err != nil {
-			cause(err)
-		}
+		// TODO: check for context cancellation in f() to prevent leaking the goroutine
+		errCh <- f(cltx)
 	}()
 
-	<-cltx.Done()
-
-	err := cltx.Err()
-	if !errors.Is(err, context.Canceled) {
+	select {
+	case <-cltx.Done():
+		err := cltx.Err()
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("Context exceeded set deadline after %v", timeout)
+		}
+		return err
+	case err := <-errCh:
 		return err
 	}
-
-	return nil
 }

--- a/cmd/hype/cli/cli.go
+++ b/cmd/hype/cli/cli.go
@@ -202,7 +202,6 @@ func WithTimeout(ctx context.Context, timeout time.Duration, f func(context.Cont
 	defer cancel()
 
 	go func() {
-		// TODO: check for context cancellation in f() to prevent leaking the goroutine
 		errCh <- f(cltx)
 	}()
 

--- a/testdata/to_md/source_code/broken/hype.md
+++ b/testdata/to_md/source_code/broken/hype.md
@@ -1,0 +1,3 @@
+# Hello
+
+<code src="src/main.go" snippet="main"></code>

--- a/testdata/to_md/source_code/broken/src/main.go
+++ b/testdata/to_md/source_code/broken/src/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+// snippet: main
+func main() {
+	fmt.Println("Hello, World!")
+}


### PR DESCRIPTION
Fixes #31 

Test with:

```go
go test -v -race -count=1 cli_errors_test.go
```

@corylanou @markbates let me know if there's a better way to test the built binary itself or if the test data should be structured differently. I'd be happy to make any further changes if need be.