### PR TITLE
Improve error handling in home directory resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -160,7 +160,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -189,7 +189,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -219,7 +219,7 @@ $ go run .
 ./main.go:7:6: undefined: fmt.Prin
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -256,7 +256,7 @@ type Context interface{ ... }
     func WithoutCancel(parent Context) Context
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -279,7 +279,7 @@ func WithCancel(parent Context) (ctx Context, cancel CancelFunc)
     call cancel as soon as the operations running in this Context complete.
 
 --------------------------------------------------------------------------------
-Go Version: go1.23.1
+Go Version: go1.23.8
 
 ```
 
@@ -308,7 +308,7 @@ $ tree
     └── hello
         └── main.go
 
-3 directories, 4 files
+4 directories, 4 files
 ```
 
 # The Export Command
@@ -375,7 +375,7 @@ $ tree ./docs
         └── hello
             └── main.go
 
-4 directories, 6 files
+5 directories, 6 files
 ```
 ---
 

--- a/cmd.go
+++ b/cmd.go
@@ -110,7 +110,11 @@ func (c *Cmd) Execute(ctx context.Context, doc *Document) error {
 	copy(args, c.Args)
 	for i, arg := range args {
 		if strings.HasPrefix(arg, "~") {
-			args[i] = filepath.Join(homeDirectory(), arg[1:])
+			hd, err := homeDirectory()
+			if err != nil {
+				return c.newError(err)
+			}
+			args[i] = filepath.Join(hd, arg[1:])
 		}
 	}
 

--- a/home.go
+++ b/home.go
@@ -1,7 +1,6 @@
 package hype
 
 import (
-	"log"
 	"os"
 )
 
@@ -9,15 +8,15 @@ import (
 // it only runs once
 var homeDir string
 
-func homeDirectory() string {
+func homeDirectory() (string, error) {
 	if homeDir != "" {
-		return homeDir
+		return homeDir, nil
 	}
 
 	hd, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	homeDir = hd
-	return homeDir
+	return homeDir, nil
 }


### PR DESCRIPTION
This PR improves error handling when resolving paths that contain the tilde (~) character for home directory expansion. Previously, the `homeDirectory()` function would log and exit the program if it failed to get the user's home directory. Now it properly returns the error to the caller, allowing for more graceful error handling.

Key changes:
- Modified `homeDirectory()` to return an error instead of calling `log.Fatal()`
- Updated the calling code in `Execute()` to handle potential errors
- Removed unused `log` import

These changes follow the Go best practice of propagating errors up the call stack rather than terminating the program at the point of failure, giving the caller more control over error handling.