### PR TITLE
Improve README Generation Workflow to Update Within PRs

### DIFF
--- a/.github/workflows/hype.yml
+++ b/.github/workflows/hype.yml
@@ -1,16 +1,17 @@
 name: Generate README with Hype
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.head_ref }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -20,10 +21,15 @@ jobs:
         run: go install github.com/gopherguides/hype/cmd/hype@latest
       - name: Run hype
         run: hype export -format=markdown -f hype.md -o README.md
-      - name: Commit README back to the repo
-        run: |-
-          git rev-parse --abbrev-ref HEAD
-          git config user.name 'GitHub Actions'
-          git config user.email 'actions@github.com'
-          git diff --quiet || (git add README.md && git commit -am "Updated README")
-          git push origin ${{github.event.pull_request.head.ref}}
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --quiet README.md || echo "changed=true" >> $GITHUB_OUTPUT
+      - name: Commit README changes if any
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add README.md
+          git commit -m "Update README.md with latest Hype changes"
+          git push


### PR DESCRIPTION
This PR modifies the Hype README generation workflow to be more integrated with our development process:

### Key Changes
- Changes workflow trigger from `push to main` to `pull_request` events
- README updates now happen within PRs instead of creating separate PRs
- Only commits README changes when actual updates are needed
- Adds proper permissions for GitHub Actions bot
- Simplifies checkout process and git configuration

### Benefits
- README changes are now coupled with the code changes that triggered them
- Easier review process as all changes are visible in the same PR
- Eliminates extra PRs just for README updates
- Respects branch protection rules by working within PR workflow
- More efficient by only committing when actual changes exist

### Technical Details
- Triggers on PR events: opened, synchronize, and reopened
- Uses GitHub Actions bot identity for commits
- Checks for actual README changes before committing