### PR TITLE
Add support for code snippets for more file formats

### DIFF
--- a/.github/workflows/hype.yml
+++ b/.github/workflows/hype.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/README.md
+++ b/README.md
@@ -422,7 +422,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/snippet.go
+++ b/snippet.go
@@ -125,12 +125,17 @@ func (sm *Snippets) init() {
 
 		if sm.rules == nil {
 			sm.rules = map[string]string{
-				".go":   "// %s",
-				".html": "<!-- %s -->",
-				".js":   "// %s",
-				".md":   "<!-- %s -->",
-				".rb":   "# %s",
-				".ts":   "// %s",
+				".go":    "// %s",
+				".html":  "<!-- %s -->",
+				".js":    "// %s",
+				".md":    "<!-- %s -->",
+				".rb":    "# %s",
+				".ts":    "// %s",
+				".sh":    "# %s",
+				".yaml":  "# %s",
+				".yml":   "# %s",
+				".env":   "# %s",
+				".envrc": "# %s",
 			}
 		}
 	})

--- a/snippet_test.go
+++ b/snippet_test.go
@@ -27,6 +27,11 @@ func Test_Parse_Snippets(t *testing.T) {
 	const rbexp = "def goodbye\n  puts \"Goodbye, World!\"\nend"
 	const jsexp = "function goodbye() {\n    console.log('Goodbye, World!');\n}"
 	const htmlexp = "<p>Goodbye World</p>"
+	const yamlexp = "address:\n  street: 123 Main St\n  city: Springfield\n  zip: 12345"
+	const ymlexp = "address:\n  street: 123 Main St\n  city: Springfield\n  zip: 12345"
+	const shexp = "echo \"Goodbye, World!\""
+	const envexp = "GOODBYE=\"goodbye\""
+	const envrcexp = "export GOODBYE=\"goodbye\""
 
 	table := []struct {
 		path  string
@@ -39,6 +44,11 @@ func Test_Parse_Snippets(t *testing.T) {
 		{path: "snippets.rb", lang: "rb", start: 7, end: 11, exp: rbexp},
 		{path: "snippets.js", lang: "js", start: 7, end: 11, exp: jsexp},
 		{path: "snippets.html", lang: "html", start: 16, end: 18, exp: htmlexp},
+		{path: "snippets.yaml", lang: "yaml", start: 5, end: 10, exp: yamlexp},
+		{path: "snippets.yml", lang: "yml", start: 5, end: 10, exp: ymlexp},
+		{path: "snippets.sh", lang: "sh", start: 3, end: 5, exp: shexp},
+		{path: "snippets.env", lang: "env", start: 1, end: 3, exp: envexp},
+		{path: ".envrc", lang: "envrc", start: 1, end: 3, exp: envrcexp},
 	}
 
 	for _, tc := range table {

--- a/testdata/json/document.json
+++ b/testdata/json/document.json
@@ -262,12 +262,17 @@
   "section_id": 1,
   "snippets": {
     "rules": {
+      ".env": "# %s",
+      ".envrc": "# %s",
       ".go": "// %s",
       ".html": "\u003c!-- %s --\u003e",
       ".js": "// %s",
       ".md": "\u003c!-- %s --\u003e",
       ".rb": "# %s",
-      ".ts": "// %s"
+      ".sh": "# %s",
+      ".ts": "// %s",
+      ".yaml": "# %s",
+      ".yml": "# %s"
     },
     "snippets": {
       "src/main.ts": {

--- a/testdata/snippets/.envrc
+++ b/testdata/snippets/.envrc
@@ -1,0 +1,6 @@
+# snippet: goodbye
+export GOODBYE="goodbye"
+# snippet: goodbye
+# snippet: hello
+export HELLO="hello"
+# snippet: hello

--- a/testdata/snippets/snippets.env
+++ b/testdata/snippets/snippets.env
@@ -1,0 +1,6 @@
+# snippet: goodbye
+GOODBYE="goodbye"
+# snippet: goodbye
+# snippet: hello
+HELLO="hello"
+# snippet: hello

--- a/testdata/snippets/snippets.sh
+++ b/testdata/snippets/snippets.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# snippet: goodbye
+echo "Goodbye, World!"
+# snippet: goodbye
+
+# snippet: hello
+echo "Hello, World!"
+# snippet: hello

--- a/testdata/snippets/snippets.yaml
+++ b/testdata/snippets/snippets.yaml
@@ -1,0 +1,17 @@
+---
+name: Jane Doe
+age: 30
+isEmployed: true
+# snippet: goodbye
+address:
+  street: 123 Main St
+  city: Springfield
+  zip: 12345
+# snippet: goodbye
+pets:
+  - type: dog
+    name: Rex
+# snippet: hello
+  - type: cat
+    name: Whiskers
+# snippet: hello

--- a/testdata/snippets/snippets.yml
+++ b/testdata/snippets/snippets.yml
@@ -1,0 +1,17 @@
+---
+name: Jane Doe
+age: 30
+isEmployed: true
+# snippet: goodbye
+address:
+  street: 123 Main St
+  city: Springfield
+  zip: 12345
+# snippet: goodbye
+pets:
+  - type: dog
+    name: Rex
+# snippet: hello
+  - type: cat
+    name: Whiskers
+# snippet: hello


### PR DESCRIPTION
Closes #41 

## Key Changes

1. adds support for using code snippets for the following file extensions:

- yaml/yml
- sh
- .env/.envrc

2. Fixes `action/checkout` step in CI allowing forks to trigger the markdown re-generation on their branches

## Implementation details

- extends the set of parsing rules to map each file extension to its corresponding syntax for comments
- adds tests in the same manner as it was for the already supported file formats
- sets `ref` in `action/checkout` to the branch that triggers the markdown generation workflow and `repo` to match the repository where the branch belongs (be that fork or origin). Originally the markdown regeneration workflow [failed](https://github.com/gopherguides/hype/actions/runs/14839576255/job/41659006488). The checkout was performed from the origin repo which couldn't find my branch from a fork. I took the solution from [comment](https://github.com/actions/checkout/issues/551#issue-937207711).

## Test

The new tests are part of the existing `Test_Parse_Snippets()`:

```bash
❯ go test -v -race -run Test_Parse_Snippets
=== RUN   Test_Parse_Snippets
=== PAUSE Test_Parse_Snippets
=== CONT  Test_Parse_Snippets
=== RUN   Test_Parse_Snippets/snippets.go
=== RUN   Test_Parse_Snippets/snippets.rb
=== RUN   Test_Parse_Snippets/snippets.js
=== RUN   Test_Parse_Snippets/snippets.html
=== RUN   Test_Parse_Snippets/snippets.yaml
=== RUN   Test_Parse_Snippets/snippets.yml
=== RUN   Test_Parse_Snippets/snippets.sh
=== RUN   Test_Parse_Snippets/snippets.env
=== RUN   Test_Parse_Snippets/.envrc
--- PASS: Test_Parse_Snippets (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.go (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.rb (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.js (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.html (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.yaml (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.yml (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.sh (0.00s)
    --- PASS: Test_Parse_Snippets/snippets.env (0.00s)
    --- PASS: Test_Parse_Snippets/.envrc (0.00s)
PASS
ok  	github.com/gopherguides/hype	1.499s
```

or as part of the whole test suite:

```bash
❯ make test
go test -count 1 -race -vet=off -cover $(go list ./... | grep -v /docs/)
ok  	github.com/gopherguides/hype	6.953s	coverage: 73.2% of statements
ok  	github.com/gopherguides/hype/atomx	1.508s	coverage: 52.9% of statements
ok  	github.com/gopherguides/hype/binding	1.430s	coverage: 62.3% of statements
	github.com/gopherguides/hype/cmd/hype		coverage: 0.0% of statements
ok  	github.com/gopherguides/hype/cmd/hype/cli	2.085s	coverage: 29.9% of statements
ok  	github.com/gopherguides/hype/internal/lone	2.044s	coverage: 54.9% of statements
ok  	github.com/gopherguides/hype/mdx	2.227s	coverage: 95.8% of statements
	github.com/gopherguides/hype/slides		coverage: 0.0% of statements
```

## Note

I had to change the order of key-value pairs for parsing rules in the resulting "gold" file (`testdata/json/document.json`) used to compare parsing results against in test. Turns out the ordering of key-value pairs when serializing maps to json [is not guaranteed](https://github.com/golang/go/issues/27179) to stay the same as was defined in a Go map object.

This seems to be an issue when adding a new key-value pair as it might potentially change the final ordering in the json object but as far as I can tell it appears to be stable across multiple runs for the same map.

---

@corylanou Please let me know how I can simplify the reviewing process for you. I saw you also made quite a few changes and made a release in the meantime so it really revitalizes the project and I'm happy to see it! Thank you for your work and responsiveness, it really makes contribution process extremely enjoyable