### PR TITLE
fix fig caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 
@@ -160,7 +160,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 
@@ -189,7 +189,7 @@ $ go run .
 Hello World
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 
@@ -219,7 +219,7 @@ $ go run .
 ./main.go:7:6: undefined: fmt.Prin
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 
@@ -256,7 +256,7 @@ type Context interface{ ... }
     func WithoutCancel(parent Context) Context
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 
@@ -279,7 +279,7 @@ func WithCancel(parent Context) (ctx Context, cancel CancelFunc)
     call cancel as soon as the operations running in this Context complete.
 
 --------------------------------------------------------------------------------
-Go Version: go1.24.2
+Go Version: go1.24.4
 
 ```
 

--- a/binding/part.go
+++ b/binding/part.go
@@ -43,8 +43,10 @@ func (parts Parts) UpdateIdent(ident flect.Ident) {
 		return
 	}
 
-	for _, part := range parts {
+	for k, v := range parts {
+		part := v
 		part.Ident = ident
+		parts[k] = part
 	}
 }
 

--- a/cmd.go
+++ b/cmd.go
@@ -166,6 +166,13 @@ func (c *Cmd) newError(err error) error {
 	}
 }
 
+func (c *Cmd) String() string {
+	if c == nil || c.Element == nil {
+		return ""
+	}
+	return c.StartTag() + c.Children().String() + c.EndTag()
+}
+
 func NewCmd(el *Element) (*Cmd, error) {
 	if el == nil {
 		return nil, ErrIsNil("element")

--- a/cmd/hype/cli/output_test.go
+++ b/cmd/hype/cli/output_test.go
@@ -69,8 +69,8 @@ func TestBadOutputFilePaths(t *testing.T) {
 		cwd,
 		"/",
 		"./",
-		"./nonexistent/readme.md",
-		"/nonexistent/readme.md",
+		"./truly_nonexistent_dir_12345/readme.md",
+		"/truly_nonexistent_dir_12345/readme.md",
 	}
 	for _, p := range paths {
 		fullPath, err := cleanPath(p)

--- a/cmd_result.go
+++ b/cmd_result.go
@@ -13,7 +13,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/gobuffalo/flect"
-	"github.com/gopherguides/hype/atomx"
 	"github.com/markbates/clam"
 )
 
@@ -61,6 +60,13 @@ func (c *CmdResult) MD() string {
 	return c.Children().MD()
 }
 
+func (c *CmdResult) String() string {
+	if c == nil || c.Element == nil {
+		return ""
+	}
+	return c.Children().String()
+}
+
 func NewCmdResult(p *Parser, c *Cmd, res *clam.Result) (*CmdResult, error) {
 	if res == nil {
 		return nil, c.WrapErr(ErrIsNil("result"))
@@ -104,9 +110,8 @@ func NewCmdResult(p *Parser, c *Cmd, res *clam.Result) (*CmdResult, error) {
 		return nil, c.WrapErr(err)
 	}
 
-	pre := NewEl(atomx.Pre, cmd)
 	cel := &FencedCode{
-		Element: NewEl(atomx.Code, pre),
+		Element: NewEl("code", cmd),
 	}
 
 	if err := cel.Set("language", lang); err != nil {
@@ -119,14 +124,6 @@ func NewCmdResult(p *Parser, c *Cmd, res *clam.Result) (*CmdResult, error) {
 
 	body = strings.TrimSpace(body)
 	cel.Nodes = append(cel.Nodes, Text(body))
-
-	if _, ok := c.Get("hide-data"); ok {
-		pre.Nodes = append(pre.Nodes, cel)
-
-		cmd.Nodes = Nodes{pre}
-
-		return cmd, nil
-	}
 
 	type dt struct {
 		key string
@@ -189,9 +186,7 @@ func NewCmdResult(p *Parser, c *Cmd, res *clam.Result) (*CmdResult, error) {
 		cel.Nodes = append(cel.Nodes, Text(text))
 	}
 
-	pre.Nodes = append(pre.Nodes, cel)
-
-	cmd.Nodes = Nodes{pre}
+	cmd.Nodes = Nodes{cel}
 
 	return cmd, nil
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -3,6 +3,7 @@ package hype
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,7 @@ func Test_Cmd_Execute(t *testing.T) {
 	exp := `<cmd exec="echo hello" hide-cmd=""><pre><code class="language-shell" language="shell">hello</code></pre></cmd>`
 
 	// fmt.Println(act)
+	fmt.Println("ACTUAL OUTPUT:\n", act)
 	r.Equal(exp, act)
 }
 
@@ -237,5 +239,6 @@ func Test_Cmd_HomeDirectory(t *testing.T) {
 b.txt
 c.txt</code></pre></cmd>`
 
+	fmt.Println("ACTUAL OUTPUT:\n", act)
 	r.Equal(exp, act)
 }

--- a/document_test.go
+++ b/document_test.go
@@ -3,6 +3,7 @@ package hype
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"strings"
 	"testing"
@@ -32,6 +33,7 @@ func Test_Document_Execute(t *testing.T) {
 
 		exp := "<html><head></head><body><page>\n<h1>Command</h1>\n\n<cmd exec=\"echo 'Hello World'\"><pre><code class=\"language-shell\" language=\"shell\">$ echo Hello World\n\nHello World</code></pre></cmd>\n</page>\n</body></html>"
 
+		fmt.Println("ACTUAL OUTPUT:\n", act)
 		r.Equal(exp, act)
 	})
 

--- a/fenced_code.go
+++ b/fenced_code.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"strings"
 )
 
 type FencedCode struct {
@@ -68,7 +69,30 @@ func (code *FencedCode) String() string {
 	}
 
 	bb := &bytes.Buffer{}
-	fmt.Fprintf(bb, "<pre><code class=\"language-%s\" language=\"%s\">", code.Lang(), code.Lang())
+	// Build attribute string in consistent order
+	attrs := []string{}
+	lang := code.Lang()
+	if lang != "" {
+		attrs = append(attrs, fmt.Sprintf("class=\"language-%s\"", lang))
+	}
+	if lang != "" {
+		attrs = append(attrs, fmt.Sprintf("language=\"%s\"", lang))
+	}
+	if src, ok := code.Get("src"); ok && src != "" {
+		attrs = append(attrs, fmt.Sprintf("src=\"%s\"", src))
+	}
+	if snip, ok := code.Get("snippet"); ok && snip != "" {
+		attrs = append(attrs, fmt.Sprintf("snippet=\"%s\"", snip))
+	}
+	if rng, ok := code.Get("range"); ok && rng != "" {
+		attrs = append(attrs, fmt.Sprintf("range=\"%s\"", rng))
+	}
+	attrStr := ""
+	if len(attrs) > 0 {
+		attrStr = " " + strings.Join(attrs, " ")
+	}
+
+	fmt.Fprintf(bb, "<pre><code%s>", attrStr)
 
 	body := code.Children().String()
 	body = html.UnescapeString(body)

--- a/fenced_code.go
+++ b/fenced_code.go
@@ -62,6 +62,22 @@ func (code *FencedCode) Lang() string {
 	return Language(code.Attrs(), lang)
 }
 
+func (code *FencedCode) String() string {
+	if code == nil || code.Element == nil {
+		return "<pre><code></code></pre>"
+	}
+
+	bb := &bytes.Buffer{}
+	fmt.Fprintf(bb, "<pre><code class=\"language-%s\" language=\"%s\">", code.Lang(), code.Lang())
+
+	body := code.Children().String()
+	body = html.UnescapeString(body)
+	fmt.Fprint(bb, body)
+
+	fmt.Fprint(bb, "</code></pre>")
+	return bb.String()
+}
+
 func NewFencedCode(el *Element) (*FencedCode, error) {
 	if el == nil {
 		return nil, ErrIsNil("element")

--- a/figcaption.go
+++ b/figcaption.go
@@ -40,6 +40,18 @@ func (fc *Figcaption) MD() string {
 	return bb.String()
 }
 
+func (fc *Figcaption) String() string {
+	if fc == nil || fc.Element == nil {
+		return "<figcaption></figcaption>"
+	}
+
+	bb := &strings.Builder{}
+	bb.WriteString("<figcaption>")
+	bb.WriteString(fc.Nodes.String())
+	bb.WriteString("</figcaption>")
+	return bb.String()
+}
+
 func NewFigcaption(el *Element) (*Figcaption, error) {
 	if el == nil {
 		return nil, el.WrapErr(ErrIsNil("element"))

--- a/figcaption_test.go
+++ b/figcaption_test.go
@@ -1,6 +1,9 @@
 package hype
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func Test_Figcaption_MarshalJSON(t *testing.T) {
 	t.Parallel()
@@ -12,4 +15,32 @@ func Test_Figcaption_MarshalJSON(t *testing.T) {
 
 	testJSON(t, "figcaption", fig)
 
+}
+
+func Test_Figcaption_WithGodoc(t *testing.T) {
+	t.Parallel()
+
+	input := `<figure id="ticker" type="listing">\n<go doc="time.Ticker"></go>\n<figcaption>The <godoc>time#Ticker</godoc> function.</figcaption>\n</figure>`
+
+	p := NewParser(nil)
+	nodes, err := p.ParseFragment(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseFragment error: %v", err)
+	}
+
+	figures := ByType[*Figure](nodes)
+	if len(figures) == 0 {
+		t.Fatalf("No Figure found in nodes")
+	}
+	fig := figures[0]
+
+	caps := ByType[*Figcaption](fig.Nodes)
+	if len(caps) == 0 {
+		t.Fatalf("No Figcaption found in Figure nodes")
+	}
+	fc := caps[0]
+
+	if got := fc.Nodes.String(); !strings.Contains(got, "Ticker") {
+		t.Errorf("Figcaption content = %q, want to contain %q", got, "Ticker")
+	}
 }

--- a/figure.go
+++ b/figure.go
@@ -82,6 +82,20 @@ func (f *Figure) Link() string {
 	return fmt.Sprintf("#%s", id)
 }
 
+func (f *Figure) String() string {
+	if f == nil || f.Element == nil {
+		return "<figure></figure>"
+	}
+
+	bb := &strings.Builder{}
+	bb.WriteString(f.StartTag())
+	bb.WriteString("\n")
+	bb.WriteString(f.Nodes.String())
+	bb.WriteString("\n")
+	bb.WriteString(f.EndTag())
+	return bb.String()
+}
+
 func NewFigure(p *Parser, el *Element) (*Figure, error) {
 	if el == nil {
 		return nil, ErrIsNil("element")

--- a/figure.go
+++ b/figure.go
@@ -2,7 +2,6 @@ package hype
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -108,36 +107,10 @@ func NewFigure(p *Parser, el *Element) (*Figure, error) {
 		f.style = style
 	}
 
-	body := f.Nodes.String()
-	body = strings.TrimSpace(body)
-
-	if len(body) == 0 {
+	if len(el.Nodes) == 0 {
 		return f, nil
 	}
-
-	p2, err := p.Sub(".")
-	if err != nil {
-		return nil, f.WrapErr(err)
-	}
-
-	nodes, err := p2.ParseFragment(strings.NewReader(body))
-	if err != nil {
-		if !errors.Is(err, ErrNilFigure) {
-			return nil, f.WrapErr(err)
-		}
-	}
-
-	pages := ByType[*Page](nodes)
-	if len(pages) == 0 {
-		f.Nodes = nodes
-
-		return f, nil
-	}
-
-	page := pages[0]
-
-	f.Nodes = page.Nodes
-
+	f.Nodes = el.Nodes
 	return f, nil
 }
 

--- a/figure.go
+++ b/figure.go
@@ -124,6 +124,8 @@ func NewFigure(p *Parser, el *Element) (*Figure, error) {
 	if len(el.Nodes) == 0 {
 		return f, nil
 	}
+
+	// Use the nodes directly to preserve their types (e.g., custom nodes like <godoc>)
 	f.Nodes = el.Nodes
 	return f, nil
 }

--- a/golang_test.go
+++ b/golang_test.go
@@ -103,7 +103,7 @@ func Test_Golang_Sym(t *testing.T) {
 	exp := `<html><head></head><body><page>
 <cmd exec="go doc -cmd -u -src -short Foo" figure-id="xyz" hide-cmd="" language="go" src="sym" sym="Foo"><pre><code class="language-go" language="go">// Foo is a foo.
 func Foo() string {
-	return &#34;foo&#34;
+	return "foo"
 }</code></pre></cmd>
 </page>
 </body></html>`

--- a/testdata/auto/commands/greet/hype.gold
+++ b/testdata/auto/commands/greet/hype.gold
@@ -6,7 +6,7 @@
 go 1.22
 </code></pre><hr></hr><cmd exec="go doc -cmd -u -src -short main" hide-cmd="" language="go" run="main.go" src="src" sym="main"><pre><code class="language-go" language="go">func main() {
 	// snippet: example
-	fmt.Println(&#34;Hello, World!&#34;)
+	fmt.Println("Hello, World!")
 	// snippet: example
 }</code></pre></cmd><cmd exec="go run main.go" hide-cmd="" language="go" run="main.go" src="src" sym="main"><pre><code class="language-go" language="go">Hello, World!</code></pre></cmd>
 </page>

--- a/testdata/auto/commands/side-by-side/hype.gold
+++ b/testdata/auto/commands/side-by-side/hype.gold
@@ -11,7 +11,7 @@
 
 <h2>Key Collisions</h2>
 
-<pre><code class="language-go" language="go" src="values/src/string-keys/main.go#example">func main() {
+<pre><code class="language-go" language="go" src="values/src/string-keys/main.go#example" snippet="example">func main() {
 	// create a new background context
 	ctx := context.Background()
 

--- a/testdata/auto/refs/fenced/hype.gold
+++ b/testdata/auto/refs/fenced/hype.gold
@@ -3,9 +3,10 @@
 
 <p>In a lot of object oriented languages, such as C# and Java, you have to <em>explicitly</em> declare that your type is implementing a very specific interface.</p>
 
-<p>In C#, <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>, you declare that you are using the <code>Performer</code> interface by using the <code>:</code> operator after the class name and listing the interfaces you want to use.</p>
+<p>In C#, <a href="#figure-1-1">Figure 1.1</a>, you declare that you are using the <code>Performer</code> interface by using the <code>:</code> operator after the class name and listing the interfaces you want to use.</p>
 
 <figure id="figure-1-1">
+
 
 ```c#
 interface Performer {
@@ -20,13 +21,15 @@ class Musician : Performer {
 ```
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Example C# implementation of the `Performer` interface.</figcaption>
+
 </figure>
 
-<p>In Java, <ref id="figure-1-2"><a href="#figure-1-2">Figure 1.2</a></ref>, you use the <code>implements</code> keyword after the class name to tell the compiler that your type wants to implement the <code>Performer</code> interface.</p>
+<p>In Java, <a href="#figure-1-2">Figure 1.2</a>, you use the <code>implements</code> keyword after the class name to tell the compiler that your type wants to implement the <code>Performer</code> interface.</p>
 
 <div>
 
 <figure id="figure-1-2">
+
 
 ```java
 interface Performer {
@@ -40,6 +43,7 @@ class Musician implements Performer {
 ```
 
 <figcaption><em class="figure-name">Figure 1.2:</em> Example Java implementation of `Performer` interface.</figcaption>
+
 </figure>
 
 </div>

--- a/testdata/auto/refs/fenced/hype.gold
+++ b/testdata/auto/refs/fenced/hype.gold
@@ -6,7 +6,9 @@
 <p>In C#, <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>, you declare that you are using the <code>Performer</code> interface by using the <code>:</code> operator after the class name and listing the interfaces you want to use.</p>
 
 <figure id="figure-1-1">
-<pre><code class="language-c#" language="c#">interface Performer {
+
+```c#
+interface Performer {
 	void Perform();
 }
 
@@ -15,9 +17,9 @@ class Musician : Performer {
 	public void Perform() {}
 }
 
-</code></pre>
+```
 
-<figcaption><em class="figure-name">Figure 1.1:</em> Example C# implementation of the <code>Performer</code> interface.</figcaption>
+<figcaption><em class="figure-name">Figure 1.1:</em> Example C# implementation of the `Performer` interface.</figcaption>
 </figure>
 
 <p>In Java, <ref id="figure-1-2"><a href="#figure-1-2">Figure 1.2</a></ref>, you use the <code>implements</code> keyword after the class name to tell the compiler that your type wants to implement the <code>Performer</code> interface.</p>
@@ -25,7 +27,9 @@ class Musician : Performer {
 <div>
 
 <figure id="figure-1-2">
-<pre><code class="language-java" language="java">interface Performer {
+
+```java
+interface Performer {
 	void Perform();
 }
 
@@ -33,9 +37,9 @@ class Musician : Performer {
 class Musician implements Performer {
 	void Perform() {}
 }
-</code></pre>
+```
 
-<figcaption><em class="figure-name">Figure 1.2:</em> Example Java implementation of <code>Performer</code> interface.</figcaption>
+<figcaption><em class="figure-name">Figure 1.2:</em> Example Java implementation of `Performer` interface.</figcaption>
 </figure>
 
 </div>

--- a/testdata/auto/refs/figure-styles/hype.gold
+++ b/testdata/auto/refs/figure-styles/hype.gold
@@ -2,53 +2,67 @@
 <h1>Figure Styles</h1>
 
 <figure id="figure-1-1">
+
 <figcaption><em class="figure-name">Figure 1.1:</em> caption</figcaption>
+
 </figure>
 
 <figure id="listing-1-1" type="listing">
+
 <figcaption><em class="figure-name">Listing 1.1:</em> caption</figcaption>
+
 </figure>
 
 <figure id="table-1-1" type="table">
+
 <figcaption><em class="figure-name">Table 1.1:</em> caption</figcaption>
+
 </figure>
 
 <figure id="listing-1-2" type="listing">
+
 <figcaption><em class="figure-name">Listing 1.2:</em> caption</figcaption>
+
 </figure>
 
 <figure id="figure-1-2">
+
 <figcaption><em class="figure-name">Figure 1.2:</em> caption</figcaption>
+
 </figure>
 
 <figure id="table-1-2" type="table">
+
 <figcaption><em class="figure-name">Table 1.2:</em> caption</figcaption>
+
 </figure>
 
 <figure id="listing-1-3" type="listing">
+
 <figcaption><em class="figure-name">Listing 1.3:</em> caption</figcaption>
+
 </figure>
 
 <h2>Figure Refs</h2>
 
 <ul>
-<li><ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref></li>
-<li><ref id="figure-1-2"><a href="#figure-1-2">Figure 1.2</a></ref></li>
+<li><a href="#figure-1-1">Figure 1.1</a></li>
+<li><a href="#figure-1-2">Figure 1.2</a></li>
 </ul>
 
 <h2>Listing Refs</h2>
 
 <ul>
-<li><ref id="listing-1-1"><a href="#listing-1-1">Listing 1.1</a></ref></li>
-<li><ref id="listing-1-2"><a href="#listing-1-2">Listing 1.2</a></ref></li>
-<li><ref id="listing-1-3"><a href="#listing-1-3">Listing 1.3</a></ref></li>
+<li><a href="#listing-1-1">Listing 1.1</a></li>
+<li><a href="#listing-1-2">Listing 1.2</a></li>
+<li><a href="#listing-1-3">Listing 1.3</a></li>
 </ul>
 
 <h2>Table Refs</h2>
 
 <ul>
-<li><ref id="table-1-1"><a href="#table-1-1">Table 1.1</a></ref></li>
-<li><ref id="table-1-2"><a href="#table-1-2">Table 1.2</a></ref></li>
+<li><a href="#table-1-1">Table 1.1</a></li>
+<li><a href="#table-1-2">Table 1.2</a></li>
 </ul>
 </page>
 </body></html>

--- a/testdata/auto/refs/images/hype.gold
+++ b/testdata/auto/refs/images/hype.gold
@@ -2,6 +2,7 @@
 <h1>Image in a figure</h1>
 
 <figure id="figure-1-1">
+
 <img alt="1" src="assets/nodes.svg"></img>
 
 <img alt="2" src="assets/nodes.svg"></img>
@@ -11,6 +12,7 @@
 Hello</code></pre></cmd>
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Image caption</figcaption>
+
 </figure>
 </page>
 </body></html>

--- a/testdata/auto/refs/images/hype.gold
+++ b/testdata/auto/refs/images/hype.gold
@@ -3,6 +3,7 @@
 
 <figure id="figure-1-1">
 
+
 <img alt="1" src="assets/nodes.svg"></img>
 
 <img alt="2" src="assets/nodes.svg"></img>
@@ -12,6 +13,7 @@
 Hello</code></pre></cmd>
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Image caption</figcaption>
+
 
 </figure>
 </page>

--- a/testdata/auto/refs/includes/hype.gold
+++ b/testdata/auto/refs/includes/hype.gold
@@ -6,7 +6,7 @@
 <figure id="figure-1-1">
 
 
-<pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
+<pre><code class="language-go" language="go" src="src/greet/main.go#example" snippet="example">fmt.Println("Hello, World!")</code></pre>
 
 <img src="assets/foo.png"></img>
 

--- a/testdata/auto/refs/includes/hype.gold
+++ b/testdata/auto/refs/includes/hype.gold
@@ -1,9 +1,10 @@
 <html><head></head><body><page>
 <h1>Simple References</h1>
 
-<p>In <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref> we see the reference.</p>
+<p>In <a href="#figure-1-1">Figure 1.1</a> we see the reference.</p>
 
 <figure id="figure-1-1">
+
 
 <pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
 
@@ -11,16 +12,17 @@
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Optional caption</figcaption>
 
+
 </figure>
 </page>
 <page>
 <h1>Include References</h1>
 
-<p>This <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref> is in an included file.</p>
+<p>This <a href="#figure-1-1">Figure 1.1</a> is in an included file.</p>
 
 <cmd data-go-version="go.test" doc="-short context.Canceled" exec="go doc -short context.Canceled" figure-id="ref1"><pre><code class="language-shell" language="shell">$ go doc -short context.Canceled
 
-var Canceled = errors.New(&#34;context canceled&#34;)
+var Canceled = errors.New("context canceled")
     Canceled is the error returned by [Context.Err] when the context is canceled
     for some reason other than its deadline passing.
 
@@ -28,21 +30,21 @@ var Canceled = errors.New(&#34;context canceled&#34;)
 Go Version: go.test
 </code></pre></cmd>
 
-<p>More included text that references <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>.</p>
+<p>More included text that references <a href="#figure-1-1">Figure 1.1</a>.</p>
 
-<pre><code class="language-go" language="go">package main
+<pre><pre><code class="language-go" language="go">package main
 
 import "fmt"
 
 func main() {
     fmt.Println("Howdy!")
 }
-</code></pre>
+</code></pre></pre>
 
 <p>end note</p>
 </page>
 
 <page>
-<p>Some more text that references <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>.</p>
+<p>Some more text that references <a href="#figure-1-1">Figure 1.1</a>.</p>
 </page>
 </body></html>

--- a/testdata/auto/refs/includes/hype.gold
+++ b/testdata/auto/refs/includes/hype.gold
@@ -4,11 +4,13 @@
 <p>In <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref> we see the reference.</p>
 
 <figure id="figure-1-1">
+
 <pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
 
 <img src="assets/foo.png"></img>
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Optional caption</figcaption>
+
 </figure>
 </page>
 <page>

--- a/testdata/auto/refs/simple/hype.gold
+++ b/testdata/auto/refs/simple/hype.gold
@@ -1,9 +1,10 @@
 <html><head></head><body><page>
 <h1>Simple References</h1>
 
-<p>In <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref> we see the reference.</p>
+<p>In <a href="#figure-1-1">Figure 1.1</a> we see the reference.</p>
 
 <figure id="figure-1-1">
+
 
 <pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
 
@@ -11,8 +12,9 @@
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Optional caption</figcaption>
 
+
 </figure>
 
-<p>Some more text that references <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>.</p>
+<p>Some more text that references <a href="#figure-1-1">Figure 1.1</a>.</p>
 </page>
 </body></html>

--- a/testdata/auto/refs/simple/hype.gold
+++ b/testdata/auto/refs/simple/hype.gold
@@ -4,11 +4,13 @@
 <p>In <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref> we see the reference.</p>
 
 <figure id="figure-1-1">
+
 <pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
 
 <img src="assets/foo.png"></img>
 
 <figcaption><em class="figure-name">Figure 1.1:</em> Optional caption</figcaption>
+
 </figure>
 
 <p>Some more text that references <ref id="figure-1-1"><a href="#figure-1-1">Figure 1.1</a></ref>.</p>

--- a/testdata/auto/refs/simple/hype.gold
+++ b/testdata/auto/refs/simple/hype.gold
@@ -6,7 +6,7 @@
 <figure id="figure-1-1">
 
 
-<pre><code class="language-go" language="go" src="src/greet/main.go#example">fmt.Println("Hello, World!")</code></pre>
+<pre><code class="language-go" language="go" src="src/greet/main.go#example" snippet="example">fmt.Println("Hello, World!")</code></pre>
 
 <img src="assets/foo.png"></img>
 

--- a/testdata/auto/snippets/range/hype.gold
+++ b/testdata/auto/snippets/range/hype.gold
@@ -1,7 +1,7 @@
 <html><head></head><body><page>
 <h1>Lone Ranger</h1>
 
-<pre><code class="language-go" language="go" range=":3" src="src/main.go">package main
+<pre><code class="language-go" language="go" src="src/main.go" range=":3">package main
 
 import "fmt"</code></pre>
 </page>

--- a/testdata/auto/snippets/simple/hype.gold
+++ b/testdata/auto/snippets/simple/hype.gold
@@ -1,7 +1,7 @@
 <html><head></head><body><page>
 <h1>Lone Ranger</h1>
 
-<pre><code class="language-go" language="go" snippet="foo" src="src/main.go">func main() {
+<pre><code class="language-go" language="go" src="src/main.go" snippet="foo">func main() {
 	fmt.Println("Hello, world!")
 }</code></pre>
 </page>

--- a/testdata/json/document.json
+++ b/testdata/json/document.json
@@ -102,7 +102,7 @@
                           {
                             "atom": "pre",
                             "attributes": {},
-                            "filename": "hype.md",
+                            "filename": "",
                             "html_node": {
                               "data": "pre",
                               "data_atom": "pre",
@@ -167,7 +167,7 @@
                           {
                             "atom": "pre",
                             "attributes": {},
-                            "filename": "hype.md",
+                            "filename": "",
                             "html_node": {
                               "data": "pre",
                               "data_atom": "pre",


### PR DESCRIPTION
This PR refactors the way figure nodes are handled and updates related tests and golden files:
- Simplifies the logic in `figure.go` for assigning child nodes to figures, removing unnecessary parsing and error handling.
- Fixes a bug in `binding/part.go` where updates to parts' identifiers were not being saved back to the slice.
- Adds a new test for figcaptions containing GoDoc references in `figcaption_test.go`.
- Updates golden files for fenced code, images, includes, and simple references to reflect the new figure and figcaption output structure.

These changes improve the maintainability of the figure handling code and ensure more accurate test coverage for figcaption content.