### PR TITLE
fix(docs): fix project structure formatting in blog README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ $ tree ./docs
 │   │   └── theme-suspended-home.png
 │   ├── README.md
 │   └── src
-│       └── deploy.yaml
+│       ├── deploy.yaml
+│       └── structure.txt
 ├── license.md
 └── quickstart
     ├── hype.md
@@ -419,7 +420,7 @@ $ tree ./docs
         └── hello
             └── main.go
 
-8 directories, 15 files
+8 directories, 16 files
 ```
 ---
 
@@ -763,7 +764,8 @@ Then enable GitHub Pages in your repo settings (Settings > Pages > Source: GitHu
 
 ## Project Structure
 
-`mysite/
+```txt
+mysite/
 ├── config.yaml             # Site configuration
 ├── content/                # Your articles
 │   └── hello-world/
@@ -774,7 +776,9 @@ Then enable GitHub Pages in your repo settings (Settings > Pages > Source: GitHu
 ├── layouts/                # Your template overrides (optional)
 ├── static/                 # Static assets (favicon, images)
 └── public/                 # Generated output
-`
+```
+> *source: docs/blog/src/structure.txt*
+
 
 ## Article Format
 

--- a/docs/blog/hype.md
+++ b/docs/blog/hype.md
@@ -81,19 +81,7 @@ Then enable GitHub Pages in your repo settings (Settings > Pages > Source: GitHu
 
 ## Project Structure
 
-```
-mysite/
-├── config.yaml             # Site configuration
-├── content/                # Your articles
-│   └── hello-world/
-│       ├── module.md       # Article content
-│       └── src/            # Code files for the article
-├── themes/                 # Installed themes
-│   └── suspended/
-├── layouts/                # Your template overrides (optional)
-├── static/                 # Static assets (favicon, images)
-└── public/                 # Generated output
-```
+<code src="src/structure.txt"></code>
 
 ## Article Format
 

--- a/docs/blog/src/structure.txt
+++ b/docs/blog/src/structure.txt
@@ -1,0 +1,11 @@
+mysite/
+├── config.yaml             # Site configuration
+├── content/                # Your articles
+│   └── hello-world/
+│       ├── module.md       # Article content
+│       └── src/            # Code files for the article
+├── themes/                 # Installed themes
+│   └── suspended/
+├── layouts/                # Your template overrides (optional)
+├── static/                 # Static assets (favicon, images)
+└── public/                 # Generated output


### PR DESCRIPTION
Fix the mangled tree structure in the blog documentation by using a code include instead of inline markdown code blocks.